### PR TITLE
Bug fixes and completed skeletons for ui, Chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,9 @@
 ## v0.1.1
 
 - Bug fix [issue #3](https://github.com/gee-community/eetasks/issues/3) 
+
+## v0.1.2
+
+- Bug fix [issue #5](https://github.com/gee-community/eetasks/issues/5) 
+- Internal improvements to `Export.image.to*`
+- Completed the skeleton for `ui` and `Chart` so they can be silently ignored in `EE Tasks: run GEE scripts`.

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
-    "package": "NODE_ENV=production node ./esbuild.js"
+    "package": "set NODE_ENV=production node ./esbuild.js"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",

--- a/src/utilities/accountPicker.ts
+++ b/src/utilities/accountPicker.ts
@@ -112,7 +112,7 @@ is picked.
 Finally, calls the callback function using the picked account, project
 and extra arguments
 */
-export async function pickAccount(project: string | null, context: vscode.ExtensionContext, callback:any, ...args: any[] | undefined[]){
+export async function pickAccount(project: string | null, context: vscode.ExtensionContext, callback:Function, ...args: any[] | undefined[]){
     let accounts:any = context.globalState.get("userAccounts");
     if(!accounts){
         vscode.window.showInformationMessage("Looking for available accounts."); 
@@ -123,7 +123,7 @@ export async function pickAccount(project: string | null, context: vscode.Extens
     let nAccounts = Object.entries(accounts).length;
     if(nAccounts===1){
         // Only one account, so there is no need to pick
-        promptProject(Object.keys(accounts)[0], callback, project, ...args);
+        promptProject(Object.keys(accounts)[0], project, callback, ...args);
         return;
     }
 
@@ -139,7 +139,7 @@ export async function pickAccount(project: string | null, context: vscode.Extens
     return;
 }
 
-export function promptProject(account:string, project:string | null, callback: any, ...args:any[] | undefined[]){
+export function promptProject(account:string, project:string | null, callback: Function, ...args:any[] | undefined[]){
     // If "earthengine", project is not required, so it is set to null
     if(account==="earthengine"){
       // No need to pick a project if using stored credentials

--- a/src/utilities/codeEditorUtils.js
+++ b/src/utilities/codeEditorUtils.js
@@ -74,6 +74,7 @@ functions, but also starts the tasks automatically.
 class ExportImage {
     constructor(ee, successCallback, errCallback){
         this.toAsset = function(...args){
+          var computed = false;
           var clientConfig = ee.arguments.extractFromFunction(
               ee.batch.Export.image.toAsset, arguments);
           if(!Object.hasOwn(clientConfig,"description")){
@@ -83,7 +84,8 @@ class ExportImage {
           // projects/PROJECT/assets/ + description
           if (Object.hasOwn(clientConfig, "region")){
             var region = clientConfig["region"];
-            if (! typeof region==='string'){
+            if (region.func){
+              computed = true;
               region.evaluate(
                   (r)=>{
               clientConfig["region"] = r;
@@ -92,12 +94,15 @@ class ExportImage {
                   }
               );
             }
+            if (!computed){
+            return ee.batch.Export.image.toAsset(clientConfig)
+            .start(successCallback, errCallback);
+            }
           }
-          return ee.batch.Export.image.toAsset(...args)
-          .start(successCallback, errCallback);
         };
 
         this.toCloudStorage = function(...args){
+          var computed = false;
           var clientConfig = ee.arguments.extractFromFunction(
               ee.batch.Export.image.toCloudStorage, arguments);
           if(!Object.hasOwn(clientConfig,"description")){
@@ -108,7 +113,8 @@ class ExportImage {
           }
           if (Object.hasOwn(clientConfig, "region")){
             var region = clientConfig["region"];
-            if (! typeof region==='string'){
+            if (region.func){
+              computed=true;
               region.evaluate(
                   (r)=>{
               clientConfig["region"] = r;
@@ -118,12 +124,14 @@ class ExportImage {
               );
             }
           }
+          if (!computed){
           return ee.batch.Export.image.toCloudStorage(clientConfig)
           .start(successCallback, errCallback);
-          
+          }
         };
 
         this.toDrive = function(...args){
+          var computed = false;
           var clientConfig = ee.arguments.extractFromFunction(
               ee.batch.Export.image.toDrive, arguments);
           if(!Object.hasOwn(clientConfig,"description")){
@@ -134,7 +142,8 @@ class ExportImage {
           }
           if (Object.hasOwn(clientConfig, "region")){
             var region = clientConfig["region"];
-            if (! typeof region==='string'){
+            if (region.func){
+              computed=true;
               region.evaluate(
                   (r)=>{
               clientConfig["region"] = r;
@@ -144,8 +153,10 @@ class ExportImage {
               );
             }
           }
+          if (!computed){
           return ee.batch.Export.image.toDrive(clientConfig)
           .start(successCallback, errCallback);
+          }
         };
     }
 }

--- a/src/utilities/codeEditorUtils.js
+++ b/src/utilities/codeEditorUtils.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /*
 Code editor utilities.
 - print: mirrors the functionality of print in the Code Editor. See:
@@ -97,8 +98,8 @@ class ExportImage {
             if (!computed){
             return ee.batch.Export.image.toAsset(clientConfig)
             .start(successCallback, errCallback);
-            }
-          }
+           }
+           }
         };
 
         this.toCloudStorage = function(...args){
@@ -125,8 +126,8 @@ class ExportImage {
             }
           }
           if (!computed){
-          return ee.batch.Export.image.toCloudStorage(clientConfig)
-          .start(successCallback, errCallback);
+            return ee.batch.Export.image.toCloudStorage(clientConfig)
+            .start(successCallback, errCallback);
           }
         };
 
@@ -154,8 +155,8 @@ class ExportImage {
             }
           }
           if (!computed){
-          return ee.batch.Export.image.toDrive(clientConfig)
-          .start(successCallback, errCallback);
+            return ee.batch.Export.image.toDrive(clientConfig)
+            .start(successCallback, errCallback);
           }
         };
     }
@@ -233,10 +234,13 @@ class ExportConstructor{
 }
 exports.Export = ExportConstructor;
    
-
 /*
-The rest are defined to be ignored:
+The rest are defined to be silently ignored:
+Map
+Chart
+ui
 */
+
 class MapConstructor{
    /*
    Empty Map Class whose functions expect
@@ -272,9 +276,391 @@ class MapConstructor{
 
 exports.Map = new MapConstructor();
 
+class uiButton{
+    constructor(label, onClick, disabled, style, imageUrl){}
+    getDisabled=function(){};
+    getImageUrl=function(){};
+    getLabel=function(){};
+    onClick=function(callback){};
+    setDisabled=function(disabled){};
+    setImageUrl=function(imageUrl){};
+    setLabel=function(label){};
+    style=function(){};
+    unlisten=function(idOrType){};
+}
+class uiChartArray{
+    constructor(){}
+    values=function(array, axis, xLabels){};
+}
+class uiChartFeature{
+    constructor(){}
+    byFeature=function(features, xProperty, yProperties){};
+    byProperty=function(features, xProperties, seriesProperty){};
+    groups=function(features, xProperty, yProperty, seriesProperty){};
+    histogram=function(features, property, maxBuckets, minBucketWidth, maxRaw){};
+}
+class uiChartImage{
+    constructor(){}
+    byClass=function(image, classBand, region, reducer, scale, classLabels, xLabels){};
+    byRegion=function(image, regions, reducer, scale, xProperty){};
+    doySeries=function(imageCollection, region, regionReducer, scale, yearReducer, startDay, endDay){};
+    doySeriesByRegion=function(imageCollection, bandName, regions, regionReducer, scale, yearReducer, seriesProperty, startDay, endDay){};
+    doySeriesByYear=function(imageCollection, bandName, region, regionReducer, scale, sameDayReducer, startDay, endDay){};
+    histogram=function(image, region, scale, maxBuckets, minBucketWidth, maxRaw, maxPixels){};
+    regions=function(image, regions, reducer, scale, seriesProperty, xLabels){};
+    series=function(imageCollection, region, reducer, scale, xProperty){};
+    seriesByRegion=function(imageCollection, regions, reducer, band, scale, xProperty, seriesProperty){};
+}
+class uiChart{
+    constructor(dataTable, chartType, options, view, downloadable){}
+    array = new uiChartArray();
+    feature = new uiChartFeature();
+    image = new uiChartImage();
+    getChartType=function(){};
+    getDataTable=function(){};
+    getDownloadable=function(){};
+    getOptions=function(){};
+    getView=function(){};
+    onClick=function(callback){};
+    setChartType=function(chartType){};
+    setDataTable=function(dataTable){};
+    setDownloadable=function(Whether){};
+    setOptions=function(options){};
+    setSeriesNames=function(seriesNames, seriesIndex){};
+    setView=function(view){};
+    style=function(){};
+    unlisten=function(idOrType){};
+}
+class uiCheckbox{
+    constructor(label, value, onChange, disabled, style){}
+    getDisabled=function(){};
+    getLabel=function(){};
+    getValue=function(){};
+    onChange=function(callback){};
+    setDisabled=function(disabled){};
+    setLabel=function(value){};
+    setValue=function(value, trigger){};
+    style=function(){};
+    unlisten=function(idOrType){};
+}
+class uiDateSlider{
+    constructor(start, end, value, period, onChange, disabled, style){}
+    getDisabled=function(){};
+    getEnd=function(){};
+    getPeriod=function(){};
+    getStart=function(){};
+    getValue=function(){};
+    onChange=function(callback){};
+    setDisabled=function(disabled){};
+    setEnd=function(value){};
+    setPeriod=function(value){};
+    setStart=function(start){};
+    setValue=function(value, trigger){};
+    style=function(){};
+    unlisten=function(idOrType){};
+}
+class uiLabel{
+    constructor(value, style, targetUrl, imageUrl){}
+    getImageUrl=function(){};
+    getUrl=function(){};
+    getValue=function(){};
+    setImageUrl=function(imageUrl){};
+    setUrl=function(targetUrl){};
+    setValue=function(value){};
+    style=function(){};
+}
+class uiMapCloudStorageLayer{
+    constructor(bucket, path, maxZoom, suffix, name, shown, opacity){}
+    getBucket=function(){};
+    getMaxZoom=function(){};
+    getName=function(){};
+    getOpacity=function(){};
+    getPath=function(){};
+    getShown=function(){};
+    getSuffix=function(){};
+    setBucket=function(bucket){};
+    setMaxZoom=function(maxZoom){};
+    setName=function(name){};
+    setOpacity=function(opacity){};
+    setPath=function(path){};
+    setShown=function(shown){};
+    setSuffix=function(suffix){};
+}
+class uiMapDrawingTools{
+    constructor(layers, shape, selected, shown, linked){}
+    addLayer=function(geometries, name, color, shown, locked){};
+    clear=function(){};
+    draw=function(){};
+    edit=function(){};
+    get=function(key){};
+    getDrawModes=function(){};
+    getLinked=function(){};
+    getMap=function(){};
+    getSelected=function(){};
+    getShape=function(){};
+    getShown=function(){};
+    layers=function(){};
+    onDraw=function(callback){};
+    onEdit=function(callback){};
+    onErase=function(callback){};
+    onLayerAdd=function(callback){};
+    onLayerConfig=function(callback){};
+    onLayerRemove=function(callback){};
+    onLayerSelect=function(callback){};
+    onSelect=function(callback){};
+    onShapeChange=function(callback){};
+    set=function(keyOrDict, value){};
+    setDrawModes=function(drawModes){};
+    setLinked=function(linked){};
+    setSelected=function(layer){};
+    setShape=function(shape){};
+    setShown=function(shown){};
+    stop=function(){};
+    toFeatureCollection=function(indexProperty){};
+    unlisten=function(idOrType){};
+}
+class uiMapFeatureViewLayer{
+    constructor(assetId, visParams, name, shown, opacity){};
+    getAssetId=function(){};
+    getName=function(){};
+    getOpacity=function(){};
+    getShown=function(){};
+    getVisParams=function(){};
+    setAssetId=function(assetId){};
+    setName=function(name){};
+    setOpacity=function(opacity){};
+    setShown=function(shown){};
+    setVisParams=function(visParams){};
+}
+class uiMapGeometryLayer{
+    constructor(geometries, name, color, shown, locked){};
+    fromGeometry=function(geometry){};
+    geometries=function(){};
+    get=function(key){};
+    getColor=function(){};
+    getEeObject=function(){};
+    getLocked=function(){};
+    getName=function(){};
+    getShown=function(){};
+    openConfigurationDialog=function(){};
+    set=function(keyOrDict, value){};
+    setColor=function(color){};
+    setLocked=function(locked){};
+    setName=function(name){};
+    setShown=function(shown){};
+    toGeometry=function(){};
+}
+class uiMapLayer{
+    constructor(eeObject, visParams, name, shown, opacity){};
+    getEeObject=function(){};
+    getName=function(){};
+    getOpacity=function(){};
+    getShown=function(){};
+    getVisParams=function(){};
+    setEeObject=function(eeObject){};
+    setName=function(name){};
+    setOpacity=function(opacity){};
+    setShown=function(shown){};
+    setVisParams=function(visParams){};
+}
+class uiMapLinker{
+    constructor(maps, event){};
+    add=function(el){};
+    forEach=function(callback){};
+    get=function(index){};
+    getJsArray=function(){};
+    insert=function(index, el){};
+    length=function(){};
+    remove=function(el){};
+    reset=function(list){};
+    set=function(index, el){};
+}
+class uiMap{
+    constructor(center, onClick, style){}
+    CloudStorageLayer = new uiMapCloudStorageLayer();
+    drawingTools = new uiMapDrawingTools();
+    FeatureViewLayer = new uiMapFeatureViewLayer();
+    GeometryLayer = new uiMapGeometryLayer();
+    MapLayer = new uiMapLayer();
+    Linker = new uiMapLinker();
+    add=function(item){};
+    addLayer=function(eeObject, visParams, name, shown, opacity){};
+    centerObject=function(object, zoom, onComplete){};
+    clear=function(){};
+    drawingTools=function(){};
+    getBounds=function(asGeoJSON){};
+    getCenter=function(){};
+    getScale=function(){};
+    getZoom=function(){};
+    insert=function(index, widget){};
+    layers=function(){};
+    onChangeBounds=function(callback){};
+    onChangeCenter=function(callback){};
+    onChangeZoom=function(callback){};
+    onClick=function(callback){};
+    onIdle=function(callback){};
+    onTileLoaded=function(callback){};
+    remove=function(item){};
+    setCenter=function(lon, lat, zoom){};
+    setControlVisibility=function(all, layerList, zoomControl, scaleControl, mapTypeControl, fullscreenControl, drawingToolsControl){};
+    setGestureHandling=function(option){};
+    setLocked=function(locked, minZoom, maxZoom){};
+    setOptions=function(mapTypeId, styles, types){};
+    setZoom=function(zoom){};
+    style=function(){};
+    unlisten=function(idOrType){};
+    widgets=function(){};
+}
+class uiPanelLayout{
+    constructor(){}
+    absolute=function(){};
+    flow=function(direction, wrap){};
+}
+class uiPanel{
+    constructor(widgets, layout, style){}
+    Layout = new uiPanelLayout();
+    add=function(widget){};
+    clear=function(){};
+    getLayout=function(){};
+    insert=function(index, widget){};
+    remove=function(widget){};
+    setLayout=function(layout){};
+    style=function(){};
+    widgets=function(){};
+}
+class uiSelect{
+    constructor(items, placeholder, value, onChange, disabled, style){}
+    getDisabled=function(){};
+    getPlaceholder=function(){};
+    getValue=function(){};
+    items=function(){};
+    onChange=function(callback){};
+    setDisabled=function(disabled){};
+    setPlaceholder=function(placeholder){};
+    setValue=function(value, trigger){};
+    style=function(){};
+    unlisten=function(idOrType){};
+}
+class uiSlider{
+    constructor(min, max, value, step, onChange, direction, disabled, style){}
+    getDisabled=function(){};
+    getMax=function(){};
+    getMin=function(){};
+    getStep=function(){};
+    getValue=function(){};
+    onChange=function(callback){};
+    onSlide=function(callback){};
+    setDisabled=function(disabled){};
+    setMax=function(value){};
+    setMin=function(value){};
+    setStep=function(value){};
+    setValue=function(value, trigger){};
+    style=function(){};
+    unlisten=function(idOrType){};
+}
+class uiSplitPanel{
+    constructor(firstPanel, secondPanel, orientation, wipe, style){}
+    getFirstPanel=function(){};
+    getOrientation=function(){};
+    getPanel=function(index){};
+    getSecondPanel=function(){};
+    getWipe=function(){};
+    setFirstPanel=function(panel){};
+    setOrientation=function(orientation){};
+    setPanel=function(index, panel){};
+    setSecondPanel=function(panel){};
+    setWipe=function(wipe){};
+    style=function(){};
+    unlisten=function(idOrType){};
+}
+class uiTextbox{
+    constructor(placeholder, value, onChange, disabled, style){}
+    getDisabled=function(){};
+    getPlaceholder=function(){};
+    getValue=function(){};
+    onChange=function(callback){};
+    setDisabled=function(disabled){};
+    setPlaceholder=function(placeholder){};
+    setValue=function(value, trigger){};
+    style=function(){};
+    unlisten=function(idOrType){};
+}
+class uiThumbnail{
+    constructor(image, params, onClick, style){}
+    getImage=function(){};
+    getParams=function(){};
+    onClick=function(callback){};
+    setImage=function(image){};
+    setParams=function(params){};
+    style=function(){};
+    unlisten=function(idOrType){};
+}
+class uidata{
+    constructor(){}
+    ActiveDictionary=function(object, allowedProperties){};
+    get=function(key){};
+    set=function(keyOrDict, value){};
+    ActiveList=function(list){};
+    add=function(el){};
+    forEach=function(callback){};
+    get=function(index){};
+    getJsArray=function(){};
+    insert=function(index, el){};
+    length=function(){};
+    remove=function(el){};
+    reset=function(list){};
+    set=function(index, el){};
+}
+class uiroot{
+    constructor(){}
+    add=function(widget){};
+    clear=function(){};
+    getLayout=function(){};
+    insert=function(index, widget){};
+    onResize=function(callback){};
+    remove=function(widget){};
+    setKeyHandler=function(keyCode, handler, description){};
+    setLayout=function(layout){};
+    widgets=function(){};
+}
+class uiurl{
+    constructor(){}
+    get=function(key, defaultValue){};
+    set=function(keyOrDict, value){};
+}
+class uiutil{
+    constructor(){}
+    clear=function(){};
+    clearTimeout=function(timeoutKey){};
+    debounce=function(func, delay, scope){};
+    getCurrentPosition=function(success, error){};
+    rateLimit=function(func, delay, scope){};
+    setInterval=function(func, delay){};
+    setTimeout=function(func, delay){};
+    throttle=function(func, delay, scope){};
+}
+/*
+Empty ui Class whose functions expect
+the same arguments as in the code editor.
+*/
 class UIConstructor{
     constructor(){}
-    // TODO
+    Button = new uiButton();
+    Chart = new uiChart();
+    Checkbox = new uiCheckbox();
+    DateSlider = new uiDateSlider();
+    Label = new uiLabel();
+    Map = new uiMap();
+    Panel = new uiPanel();
+    Select = new uiSelect();
+    Slider = new uiSlider();
+    SplitPanel = new uiSplitPanel();
+    Textbox = new uiTextbox();
+    Thumbnail = new uiThumbnail();
+    root = new uiroot();
+    url = new uiurl(); 
+    util = new uiutil();
+    Key=null;
 }
 exports.ui = new UIConstructor();
 
@@ -312,7 +698,6 @@ class ChartConstructor{
   array = new ChartArrayConstructor();
   feature = new ChartFeatureConstructor();
   image = new ChartImageConstructor();
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   Chart=function(dataTable, chartType, options, view){};
   setChartType=function(chartType){};
   setDataTable=function(dataTable){};

--- a/src/utilities/scriptRunners.ts
+++ b/src/utilities/scriptRunners.ts
@@ -50,7 +50,10 @@ import fs = require("fs");
 var ee = require("@google/earthengine"); 
 const scriptPrefix = "exports.main=function(ee,ceu, onTaskStart, onTaskStartError, vslog){" +
 "var log=ceu.Log(vslog);" +
-"var print=ceu.Print(log);var Map=ceu.Map; " +
+"var print=ceu.Print(log);"+
+"var Map=ceu.Map; " +
+"var Chart=ceu.Chart;" + 
+"var ui = ceu.ui;" +
 "Export = new ceu.Export(ee, onTaskStart, onTaskStartError);";
 const scriptSuffix = "\n}";
 


### PR DESCRIPTION
This pull request fixes the order of the `callback `and `project` parameters in the call to `promptProject` in the case where there is only one account available. The misplaced order was the cause of #5 

Additionally, the check on the `region` parameter in `Export.image.to*` was improved by using `region.func`, which is consistent with [ee.Geometry.prototype.toGeoJSON](https://github.com/google/earthengine-api/blob/master/javascript/src/geometry.js#L713). 

A small change in  `package.json` was added so that `vsce package` may work in windows as well. 

Finally, the skeleton classes for ui and Chart are now completed and were added to the scriptRunner. Calls to ui and Chart can now be silently ignored when using `EE Tasks: run GEE scripts`. 
