### PR TITLE
Adds tasks table metadata

### DIFF
--- a/src/panels/EETasksPanel.ts
+++ b/src/panels/EETasksPanel.ts
@@ -62,6 +62,7 @@ export class EETasksPanel {
   Main ee initialization and callback to retrieve the ee tasks
   */
   private _eeTasks(project:any){
+    try{
     ee.initialize(null, null, 
     ()=>{
         try{
@@ -75,8 +76,10 @@ export class EETasksPanel {
             return;
         }
     }, 
-    (error:any)=>{console.log("Error initializing earth engine. \n"); console.log(error);}, 
+    (error:any)=>{vscode.window.showErrorMessage("Error initializing earth engine. \n"+error);}, 
     null, project);
+    }catch(err){
+    };
   }
 
   /*
@@ -127,6 +130,7 @@ export class EETasksPanel {
         EndTime: string;
         BatchEECU: string;
     }[] = []; 
+    if(tasks){
     tasks.forEach((element: {metadata: any; name: any;}) => {
       name = element.name;
       metadata = element.metadata;
@@ -142,6 +146,7 @@ export class EETasksPanel {
       };
       data.push(row);
     });
+    }
     return data;
   }
 
@@ -216,8 +221,11 @@ export class EETasksPanel {
           <title>Earth Engine Task Manager</title>
         </head>
         <body>
-          <vscode-button id="refresh">🔄</vscode-button> 
-          <p id="status-label"><p>
+        <div>
+          <vscode-button id="refresh">🔄</vscode-button>
+          <p style="display:inline" id="stats-label"></p>
+        </div>
+          <p id="status-label"></p>
           <vscode-data-grid id="basic-grid" aria-label="Basic" generate-header="sticky"></vscode-data-grid>
            <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
         </body>

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -45,18 +45,42 @@ function handleRefreshClick() {
   });
 }
 
+function countState(data:[any], state:string){
+    let N = 0;
+    data.forEach((x)=>{
+    if("State" in x){
+        if(x["State"]===state){
+            N+=1;
+        }
+    }
+    });
+    return N;
+}
+
 function updateTable(data:any){
+const label = document.getElementById('status-label');
 if (data.length<1){
-  const label = document.getElementById('status-label');
   if(label){
   label.textContent = "No tasks found.";
   }
-
 }else{
+const statsLabel = document.getElementById('stats-label');
 const grid = document.getElementById("basic-grid") as DataGrid; 
 grid.rowsData = data; 
-const label = document.getElementById('status-label');
 if(label){label.textContent = "";}
+if(statsLabel){
+    const nTotal = data.length;
+    const nDone = countState(data, "SUCCEEDED");
+    const nRunning = countState(data, "RUNNING");
+    const nPending = countState(data, "PENDING");
+    const nCancelled = countState(data, "CANCELLED");
+
+    statsLabel.textContent = `  ${nTotal} tasks in total  `+
+    `|  COMPLETED: ${nDone}   `+
+    `|  RUNNING: ${nRunning}   `+
+    `|  PENDING: ${nPending}   `+
+    `|  CANCELLED: ${nCancelled}`;
+  }
 }
 
 vscode.setState(data);


### PR DESCRIPTION
This pull request adds an additional label in the EE Tasks panel that shows the total number of tasks and a breakdown by State (COMPLETED, RUNNING, etc..):

![image](https://github.com/gee-community/eetasks/assets/14804652/aafb838c-91b4-47a9-8409-d3b9580e3cb5)
